### PR TITLE
file names should start with slash

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,6 +62,9 @@ func New(config ...Config) func(*fiber.Ctx) {
 			return
 		}
 		p = strings.TrimPrefix(p, cfg.Prefix)
+		if !strings.HasPrefix(p, "/") {
+			p = "/" + p
+		}
 
 		file, err := cfg.Root.Open(filepath.Clean(p))
 		if err != nil {


### PR DESCRIPTION
some providers (e.g. pkger) needs to start file name with slash